### PR TITLE
Generate heap-backed FSM with create/destroy funcs

### DIFF
--- a/examples/models/fsm/example.fsm.hpp
+++ b/examples/models/fsm/example.fsm.hpp
@@ -1,6 +1,6 @@
 /*
  * This is an auto-generated file. Do not edit it directly.
- * 
+ *
  * FSM: example
  * FSM Description: Example of a simple FSM
  *
@@ -30,16 +30,19 @@ void fsm_behavior(struct events *eventData, struct user_data *userData) {
 int main() {
 
     struct user_data userData = {};
+    struct fsm_nbx *fsm = create_fsm();
+    if (!fsm) return 1;
 
     while (true) {
-        produce_event(fsm.eventData, E_STEP);
+        produce_event(fsm->eventData, E_STEP);
 
         // run state machine, event loop
-        fsm_behavior(fsm.eventData, &userData);
-        fsm_step_nbx(&fsm);
-        reconfig_event_buffers(&eventData);
+        fsm_behavior(fsm->eventData, &userData);
+        fsm_step_nbx(fsm);
+        reconfig_event_buffers(fsm->eventData);
     }
 
+    destroy_fsm(fsm);
     return 0;
 }
 
@@ -51,6 +54,18 @@ int main() {
 
 #include "coord2b/functions/fsm.h"
 #include "coord2b/functions/event_loop.h"
+#include <new>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct fsm_nbx * create_fsm();
+void destroy_fsm(struct fsm_nbx * fsm);
+
+#ifdef __cplusplus
+}
+#endif
 
 // sm states
 enum e_states {
@@ -104,139 +119,201 @@ enum e_reactions {
     NUM_REACTIONS
 };
 
-// sm states
-inline struct state states[NUM_STATES] = {
-    {.name = "S_start"}, 
-    {.name = "S_configure"}, 
-    {.name = "S_idle"}, 
-    {.name = "S_compile"}, 
-    {.name = "S_execute"}, 
-    {.name = "S_exit"} 
-};
+inline struct fsm_nbx * create_fsm() {
 
-// sm transition table
-inline struct transition transitions[NUM_TRANSITIONS] = {
-    {
+    struct fsm_nbx * fsm = new (std::nothrow) fsm_nbx{
+        .numReactions = NUM_REACTIONS,
+        .numTransitions = NUM_TRANSITIONS,
+        .numStates = NUM_STATES,
         .startStateIndex = S_START,
-        .endStateIndex = S_CONFIGURE,
-    }, 
-    {
-        .startStateIndex = S_CONFIGURE,
-        .endStateIndex = S_IDLE,
-    }, 
-    {
-        .startStateIndex = S_IDLE,
-        .endStateIndex = S_IDLE,
-    }, 
-    {
-        .startStateIndex = S_IDLE,
-        .endStateIndex = S_EXECUTE,
-    }, 
-    {
-        .startStateIndex = S_IDLE,
-        .endStateIndex = S_COMPILE,
-    }, 
-    {
-        .startStateIndex = S_COMPILE,
-        .endStateIndex = S_EXECUTE,
-    }, 
-    {
-        .startStateIndex = S_EXECUTE,
-        .endStateIndex = S_EXECUTE,
-    }, 
-    {
-        .startStateIndex = S_EXECUTE,
-        .endStateIndex = S_IDLE,
-    } 
-};
+        .endStateIndex = S_EXIT,
+        .currentStateIndex = S_START
+    };
+    if (!fsm) return nullptr;
 
-// sm reaction table
-inline struct event_reaction reactions[NUM_REACTIONS] = {
-    {
-        .conditionEventIndex = E_CONFIGURE_EXIT,
-        .transitionIndex = T_CONFIGURE_IDLE,
-        .numFiredEvents = 1,
-        .firedEventIndices = new unsigned int[1]{
-            E_IDLE_ENTERED 
-        },
-    }, 
-    {
-        .conditionEventIndex = E_IDLE_EXIT_EXECUTE,
-        .transitionIndex = T_IDLE_EXECUTE,
-        .numFiredEvents = 1,
-        .firedEventIndices = new unsigned int[1]{
-            E_EXECUTE_ENTERED 
-        },
-    }, 
-    {
-        .conditionEventIndex = E_IDLE_EXIT_COMPILE,
-        .transitionIndex = T_IDLE_COMPILE,
-        .numFiredEvents = 1,
-        .firedEventIndices = new unsigned int[1]{
-            E_COMPILE_ENTERED 
-        },
-    }, 
-    {
-        .conditionEventIndex = E_COMPILE_EXIT,
-        .transitionIndex = T_COMPILE_EXECUTE,
-        .numFiredEvents = 1,
-        .firedEventIndices = new unsigned int[1]{
-            E_EXECUTE_ENTERED 
-        },
-    }, 
-    {
-        .conditionEventIndex = E_EXECUTE_EXIT,
-        .transitionIndex = T_EXECUTE_IDLE,
-        .numFiredEvents = 1,
-        .firedEventIndices = new unsigned int[1]{
-            E_IDLE_ENTERED 
-        },
-    }, 
-    {
-        .conditionEventIndex = E_STEP,
-        .transitionIndex = T_START_CONFIGURE,
-        .numFiredEvents = 1,
-        .firedEventIndices = new unsigned int[1]{
-            E_CONFIGURE_ENTERED 
-        },
-    }, 
-    {
-        .conditionEventIndex = E_STEP,
-        .transitionIndex = T_IDLE_IDLE,
-        .numFiredEvents = 0,
-        .firedEventIndices = nullptr,
+    // sm states
+    struct state * states = new (std::nothrow) state[NUM_STATES]{
+        {.name = "S_start"}, 
+        {.name = "S_configure"}, 
+        {.name = "S_idle"}, 
+        {.name = "S_compile"}, 
+        {.name = "S_execute"}, 
+        {.name = "S_exit"} 
+    };
 
-    }, 
-    {
-        .conditionEventIndex = E_STEP,
-        .transitionIndex = T_EXECUTE_EXECUTE,
-        .numFiredEvents = 0,
-        .firedEventIndices = nullptr,
+    // sm transition table
+    struct transition * transitions = new (std::nothrow) transition[NUM_TRANSITIONS]{
+        {
+            .startStateIndex = S_START,
+            .endStateIndex = S_CONFIGURE,
+        }, 
+        {
+            .startStateIndex = S_CONFIGURE,
+            .endStateIndex = S_IDLE,
+        }, 
+        {
+            .startStateIndex = S_IDLE,
+            .endStateIndex = S_IDLE,
+        }, 
+        {
+            .startStateIndex = S_IDLE,
+            .endStateIndex = S_EXECUTE,
+        }, 
+        {
+            .startStateIndex = S_IDLE,
+            .endStateIndex = S_COMPILE,
+        }, 
+        {
+            .startStateIndex = S_COMPILE,
+            .endStateIndex = S_EXECUTE,
+        }, 
+        {
+            .startStateIndex = S_EXECUTE,
+            .endStateIndex = S_EXECUTE,
+        }, 
+        {
+            .startStateIndex = S_EXECUTE,
+            .endStateIndex = S_IDLE,
+        } 
+    };
 
-    } 
-};
+    // sm reaction table
+    struct event_reaction * reactions = new (std::nothrow) event_reaction[NUM_REACTIONS]{
+        {
+            .conditionEventIndex = E_CONFIGURE_EXIT,
+            .transitionIndex = T_CONFIGURE_IDLE,
+            .numFiredEvents = 1,
+            .firedEventIndices = new unsigned int[1]{
+                E_IDLE_ENTERED 
+            },
+        }, 
+        {
+            .conditionEventIndex = E_IDLE_EXIT_EXECUTE,
+            .transitionIndex = T_IDLE_EXECUTE,
+            .numFiredEvents = 1,
+            .firedEventIndices = new unsigned int[1]{
+                E_EXECUTE_ENTERED 
+            },
+        }, 
+        {
+            .conditionEventIndex = E_IDLE_EXIT_COMPILE,
+            .transitionIndex = T_IDLE_COMPILE,
+            .numFiredEvents = 1,
+            .firedEventIndices = new unsigned int[1]{
+                E_COMPILE_ENTERED 
+            },
+        }, 
+        {
+            .conditionEventIndex = E_COMPILE_EXIT,
+            .transitionIndex = T_COMPILE_EXECUTE,
+            .numFiredEvents = 1,
+            .firedEventIndices = new unsigned int[1]{
+                E_EXECUTE_ENTERED 
+            },
+        }, 
+        {
+            .conditionEventIndex = E_EXECUTE_EXIT,
+            .transitionIndex = T_EXECUTE_IDLE,
+            .numFiredEvents = 1,
+            .firedEventIndices = new unsigned int[1]{
+                E_IDLE_ENTERED 
+            },
+        }, 
+        {
+            .conditionEventIndex = E_STEP,
+            .transitionIndex = T_START_CONFIGURE,
+            .numFiredEvents = 1,
+            .firedEventIndices = new unsigned int[1]{
+                E_CONFIGURE_ENTERED 
+            },
+        }, 
+        {
+            .conditionEventIndex = E_STEP,
+            .transitionIndex = T_IDLE_IDLE,
+            .numFiredEvents = 0,
+            .firedEventIndices = nullptr,
+    
+        }, 
+        {
+            .conditionEventIndex = E_STEP,
+            .transitionIndex = T_EXECUTE_EXECUTE,
+            .numFiredEvents = 0,
+            .firedEventIndices = nullptr,
+    
+        } };
 
-// sm event data
-inline struct events eventData = {
-    .numEvents = NUM_EVENTS,
-    .currentEvents = new _Bool[NUM_EVENTS]{false},
-    .futureEvents = new _Bool[NUM_EVENTS]{false},
-};
+    if (!states || !transitions || !reactions) {
+        delete[] states;
+        delete[] transitions;
+        delete[] reactions;
+        delete fsm;
+        return nullptr;
+    }
 
-// sm fsm struct
-inline struct fsm_nbx fsm = {
-    .numReactions = NUM_REACTIONS,
-    .numTransitions = NUM_TRANSITIONS,
-    .numStates = NUM_STATES,
+    for (unsigned int i = 0; i < NUM_REACTIONS; ++i) {
+        if (reactions[i].numFiredEvents > 0 && !reactions[i].firedEventIndices) {
+            for (unsigned int j = 0; j < NUM_REACTIONS; ++j) {
+                delete[] reactions[j].firedEventIndices;
+            }
+            delete[] reactions;
+            delete[] transitions;
+            delete[] states;
+            delete fsm;
+            return nullptr;
+        }
+    }
 
-    .states = states,
-    .startStateIndex = S_START,
-    .endStateIndex = S_EXIT,
-    .currentStateIndex = S_START,
+    // sm event data
+    struct events * eventData = new (std::nothrow) events{};
+    _Bool * currentEvents = new (std::nothrow) _Bool[NUM_EVENTS]{false};
+    _Bool * futureEvents = new (std::nothrow) _Bool[NUM_EVENTS]{false};
+    if (!eventData || !currentEvents || !futureEvents) {
+        delete[] states;
+        delete[] transitions;
+        if (reactions) {
+            for (unsigned int i = 0; i < NUM_REACTIONS; ++i) {
+                delete[] reactions[i].firedEventIndices;
+            }
+        }
+        delete[] reactions;
+        delete[] currentEvents;
+        delete[] futureEvents;
+        delete eventData;
+        delete fsm;
+        return nullptr;
+    }
+    eventData->numEvents = NUM_EVENTS;
+    eventData->currentEvents = currentEvents;
+    eventData->futureEvents = futureEvents;
 
-    .eventData = &eventData,
-    .reactions = reactions,
-    .transitions = transitions,
-};
+    // sm fsm struct
+    fsm->states = states;
+    fsm->eventData = eventData;
+    fsm->reactions = reactions;
+    fsm->transitions = transitions;
+
+    return fsm;
+}
+
+inline void destroy_fsm(struct fsm_nbx * fsm) {
+    if (!fsm) return;
+    if (fsm->reactions) {
+        for (unsigned int i = 0; i < fsm->numReactions; ++i) {
+            delete[] fsm->reactions[i].firedEventIndices;
+            fsm->reactions[i].firedEventIndices = nullptr;
+            fsm->reactions[i].numFiredEvents = 0;
+        }
+    }
+    if (fsm->eventData) {
+        delete[] fsm->eventData->currentEvents;
+        delete[] fsm->eventData->futureEvents;
+        delete fsm->eventData;
+        fsm->eventData = nullptr;
+    }
+    delete[] fsm->reactions;
+    delete[] fsm->transitions;
+    delete[] fsm->states;
+    delete fsm;
+}
 
 #endif // EXAMPLE_FSM_HPP

--- a/examples/models/fsm/example.fsm.hpp
+++ b/examples/models/fsm/example.fsm.hpp
@@ -56,16 +56,8 @@ int main() {
 #include "coord2b/functions/event_loop.h"
 #include <new>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 struct fsm_nbx * create_fsm();
 void destroy_fsm(struct fsm_nbx * fsm);
-
-#ifdef __cplusplus
-}
-#endif
 
 // sm states
 enum e_states {

--- a/examples/models/fsm/test_fsm.cpp
+++ b/examples/models/fsm/test_fsm.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <csignal>
 #include <iostream>
 #include <ostream>
 #include <thread>
@@ -6,49 +7,63 @@
 #include "coord2b/types/fsm.h"
 #include "example.fsm.hpp"
 
+sig_atomic_t stopFlag = 0;
+
+void
+handler(int) {
+    stopFlag = 1;
+}
+
 
 int main() {
     using clock = std::chrono::steady_clock;
+
+    signal(SIGINT, &handler);
+
     constexpr auto tick_period = std::chrono::microseconds(1000);  // 1kHz
     constexpr auto print_period = std::chrono::milliseconds(500);  // 2Hz
     auto next_tick = clock::now();
     auto now = clock::now();
     auto next_print = now + print_period;
+
+    auto fsm = create_fsm();
     bool compile = true;
-    while (true) {
+    while (!stopFlag) {
         next_tick += tick_period;
 
-        produce_event(fsm.eventData, E_STEP);
+        produce_event(fsm->eventData, E_STEP);
 
         // run state machine, event loop
-        fsm_step_nbx(&fsm);
-        reconfig_event_buffers(&eventData);
+        fsm_step_nbx(fsm);
+        reconfig_event_buffers(fsm->eventData);
 
         // handle print
         now = clock::now();
         if (now > next_print) {
             next_print += print_period;
-            std::cout << "State: " << fsm.states[fsm.currentStateIndex].name << std::endl;
+            std::cout << "State: " << fsm->states[fsm->currentStateIndex].name << std::endl;
 
             // simple inline behaviour to go through all states
-            if (fsm.currentStateIndex == S_CONFIGURE) {
-                produce_event(fsm.eventData, E_CONFIGURE_EXIT);
-            } else if (fsm.currentStateIndex == S_IDLE) {
+            if (fsm->currentStateIndex == S_CONFIGURE) {
+                produce_event(fsm->eventData, E_CONFIGURE_EXIT);
+            } else if (fsm->currentStateIndex == S_IDLE) {
                 if (compile) {
-                    produce_event(fsm.eventData, E_IDLE_EXIT_COMPILE);
+                    produce_event(fsm->eventData, E_IDLE_EXIT_COMPILE);
                 } else {
-                    produce_event(fsm.eventData, E_IDLE_EXIT_EXECUTE);
+                    produce_event(fsm->eventData, E_IDLE_EXIT_EXECUTE);
                 }
                 compile = !compile;
-            } else if (fsm.currentStateIndex == S_COMPILE) {
-                produce_event(fsm.eventData, E_COMPILE_EXIT);
-            } else if (fsm.currentStateIndex == S_EXECUTE) {
-                produce_event(fsm.eventData, E_EXECUTE_EXIT);
+            } else if (fsm->currentStateIndex == S_COMPILE) {
+                produce_event(fsm->eventData, E_COMPILE_EXIT);
+            } else if (fsm->currentStateIndex == S_EXECUTE) {
+                produce_event(fsm->eventData, E_EXECUTE_EXIT);
             }
         }
 
         std::this_thread::sleep_until(next_tick);
     }
+
+    destroy_fsm(fsm);
 
     return 0;
 }

--- a/src/coord_dsl/templates/fsm.hpp.jinja2
+++ b/src/coord_dsl/templates/fsm.hpp.jinja2
@@ -1,6 +1,6 @@
 /*
  * This is an auto-generated file. Do not edit it directly.
- * 
+ *
  * FSM: {{ data.name }}
  * FSM Description: {{ data.description }}
  *
@@ -30,16 +30,19 @@ void fsm_behavior(struct events *eventData, struct user_data *userData) {
 int main() {
 
     struct user_data userData = {};
+    struct fsm_nbx *fsm = create_fsm();
+    if (!fsm) return 1;
 
     while (true) {
-        produce_event(fsm.eventData, E_STEP);
+        produce_event(fsm->eventData, E_STEP);
 
         // run state machine, event loop
-        fsm_behavior(fsm.eventData, &userData);
-        fsm_step_nbx(&fsm);
-        reconfig_event_buffers(&eventData);
+        fsm_behavior(fsm->eventData, &userData);
+        fsm_step_nbx(fsm);
+        reconfig_event_buffers(fsm->eventData);
     }
 
+    destroy_fsm(fsm);
     return 0;
 }
 
@@ -51,6 +54,18 @@ int main() {
 
 #include "coord2b/functions/fsm.h"
 #include "coord2b/functions/event_loop.h"
+#include <new>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct fsm_nbx * create_fsm();
+void destroy_fsm(struct fsm_nbx * fsm);
+
+#ifdef __cplusplus
+}
+#endif
 
 // sm states
 enum e_states {
@@ -84,64 +99,127 @@ enum e_reactions {
     NUM_REACTIONS
 };
 
-// sm states
-inline struct state states[NUM_STATES] = {
-{%- for state in data.states %}
-    {.name = "{{ state.capitalize() }}"}{% if loop.last %} {% else %}, {% endif %}
-{%- endfor %}
-};
+inline struct fsm_nbx * create_fsm() {
 
-// sm transition table
-inline struct transition transitions[NUM_TRANSITIONS] = {
-{%- for _, transition in data.transitions_table.items() %}
-    {
-        .startStateIndex = {{ transition.from }},
-        .endStateIndex = {{ transition.to }},
-    }{% if loop.last %} {% else %}, {% endif %}
-{%- endfor %}
-};
+    struct fsm_nbx * fsm = new (std::nothrow) fsm_nbx{
+        .numReactions = NUM_REACTIONS,
+        .numTransitions = NUM_TRANSITIONS,
+        .numStates = NUM_STATES,
+        .startStateIndex = {{ data.start_state }},
+        .endStateIndex = {{ data.end_state }},
+        .currentStateIndex = {{ data.current_state }}
+    };
+    if (!fsm) return nullptr;
 
-// sm reaction table
-inline struct event_reaction reactions[NUM_REACTIONS] = {
-{%- for _, reaction in data.reactions_table.items() %}
-    {
-        .conditionEventIndex = {{ reaction.when }},
-        .transitionIndex = {{ reaction.do }},
-        .numFiredEvents = {{ reaction.num_fires }},
-{%- if reaction.fires %}
-        .firedEventIndices = new unsigned int[{{ reaction.num_fires }}]{
-{%- for event in reaction.fires %}
-            {{ event }}{% if loop.last %} {% else %}, {% endif %}
-{%- endfor %}
-        },
-{%- else %}
-        .firedEventIndices = nullptr,
-{% endif %}
-    }{% if loop.last %} {% else %}, {% endif %}
-{%- endfor %}
-};
+    // sm states
+    struct state * states = new (std::nothrow) state[NUM_STATES]{
+    {%- for state in data.states %}
+        {.name = "{{ state.capitalize() }}"}{% if loop.last %} {% else %}, {% endif %}
+    {%- endfor %}
+    };
 
-// sm event data
-inline struct events eventData = {
-    .numEvents = NUM_EVENTS,
-    .currentEvents = new _Bool[NUM_EVENTS]{false},
-    .futureEvents = new _Bool[NUM_EVENTS]{false},
-};
+    // sm transition table
+    struct transition * transitions = new (std::nothrow) transition[NUM_TRANSITIONS]{
+    {%- for _, transition in data.transitions_table.items() %}
+        {
+            .startStateIndex = {{ transition.from }},
+            .endStateIndex = {{ transition.to }},
+        }{% if loop.last %} {% else %}, {% endif %}
+    {%- endfor %}
+    };
 
-// sm fsm struct
-inline struct fsm_nbx fsm = {
-    .numReactions = NUM_REACTIONS,
-    .numTransitions = NUM_TRANSITIONS,
-    .numStates = NUM_STATES,
+    // sm reaction table
+    struct event_reaction * reactions = new (std::nothrow) event_reaction[NUM_REACTIONS]{
+    {%- for _, reaction in data.reactions_table.items() %}
+        {
+            .conditionEventIndex = {{ reaction.when }},
+            .transitionIndex = {{ reaction.do }},
+            .numFiredEvents = {{ reaction.num_fires }},
+    {%- if reaction.fires %}
+            .firedEventIndices = new unsigned int[{{ reaction.num_fires }}]{
+    {%- for event in reaction.fires %}
+                {{ event }}{% if loop.last %} {% else %}, {% endif %}
+    {%- endfor %}
+            },
+    {%- else %}
+            .firedEventIndices = nullptr,
+    {% endif %}
+        }{% if loop.last %} {% else %}, {% endif %}
+    {%- endfor -%}
+    };
 
-    .states = states,
-    .startStateIndex = {{ data.start_state }},
-    .endStateIndex = {{ data.end_state }},
-    .currentStateIndex = {{ data.current_state }},
+    if (!states || !transitions || !reactions) {
+        delete[] states;
+        delete[] transitions;
+        delete[] reactions;
+        delete fsm;
+        return nullptr;
+    }
 
-    .eventData = &eventData,
-    .reactions = reactions,
-    .transitions = transitions,
-};
+    for (unsigned int i = 0; i < NUM_REACTIONS; ++i) {
+        if (reactions[i].numFiredEvents > 0 && !reactions[i].firedEventIndices) {
+            for (unsigned int j = 0; j < NUM_REACTIONS; ++j) {
+                delete[] reactions[j].firedEventIndices;
+            }
+            delete[] reactions;
+            delete[] transitions;
+            delete[] states;
+            delete fsm;
+            return nullptr;
+        }
+    }
+
+    // sm event data
+    struct events * eventData = new (std::nothrow) events{};
+    _Bool * currentEvents = new (std::nothrow) _Bool[NUM_EVENTS]{false};
+    _Bool * futureEvents = new (std::nothrow) _Bool[NUM_EVENTS]{false};
+    if (!eventData || !currentEvents || !futureEvents) {
+        delete[] states;
+        delete[] transitions;
+        if (reactions) {
+            for (unsigned int i = 0; i < NUM_REACTIONS; ++i) {
+                delete[] reactions[i].firedEventIndices;
+            }
+        }
+        delete[] reactions;
+        delete[] currentEvents;
+        delete[] futureEvents;
+        delete eventData;
+        delete fsm;
+        return nullptr;
+    }
+    eventData->numEvents = NUM_EVENTS;
+    eventData->currentEvents = currentEvents;
+    eventData->futureEvents = futureEvents;
+
+    // sm fsm struct
+    fsm->states = states;
+    fsm->eventData = eventData;
+    fsm->reactions = reactions;
+    fsm->transitions = transitions;
+
+    return fsm;
+}
+
+inline void destroy_fsm(struct fsm_nbx * fsm) {
+    if (!fsm) return;
+    if (fsm->reactions) {
+        for (unsigned int i = 0; i < fsm->numReactions; ++i) {
+            delete[] fsm->reactions[i].firedEventIndices;
+            fsm->reactions[i].firedEventIndices = nullptr;
+            fsm->reactions[i].numFiredEvents = 0;
+        }
+    }
+    if (fsm->eventData) {
+        delete[] fsm->eventData->currentEvents;
+        delete[] fsm->eventData->futureEvents;
+        delete fsm->eventData;
+        fsm->eventData = nullptr;
+    }
+    delete[] fsm->reactions;
+    delete[] fsm->transitions;
+    delete[] fsm->states;
+    delete fsm;
+}
 
 #endif // {{ data.name.upper()  }}_FSM_HPP

--- a/src/coord_dsl/templates/fsm.hpp.jinja2
+++ b/src/coord_dsl/templates/fsm.hpp.jinja2
@@ -56,16 +56,8 @@ int main() {
 #include "coord2b/functions/event_loop.h"
 #include <new>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 struct fsm_nbx * create_fsm();
 void destroy_fsm(struct fsm_nbx * fsm);
-
-#ifdef __cplusplus
-}
-#endif
 
 // sm states
 enum e_states {


### PR DESCRIPTION
* Avoid declaring FSM structs as global variable in generated hpp file. Instead, generate create_fsm() as an owning allocator and adding destroy_fsm() for cleanup.
* Update generated usage to pointer-based FSM access.