### PR TITLE
add misisng field initializations, fix includes

### DIFF
--- a/src/coord_dsl/templates/fsm.hpp.jinja2
+++ b/src/coord_dsl/templates/fsm.hpp.jinja2
@@ -52,8 +52,8 @@ int main() {
 #ifndef {{ data.name.upper() }}_FSM_HPP
 #define {{ data.name.upper()  }}_FSM_HPP
 
-#include "coord2b/functions/fsm.h"
-#include "coord2b/functions/event_loop.h"
+#include "coord2b/types/fsm.h"
+#include "coord2b/types/event_loop.h"
 #include <new>
 
 struct fsm_nbx * create_fsm();
@@ -97,9 +97,13 @@ inline struct fsm_nbx * create_fsm() {
         .numReactions = NUM_REACTIONS,
         .numTransitions = NUM_TRANSITIONS,
         .numStates = NUM_STATES,
+        .states = nullptr,
         .startStateIndex = {{ data.start_state }},
         .endStateIndex = {{ data.end_state }},
-        .currentStateIndex = {{ data.current_state }}
+        .currentStateIndex = {{ data.current_state }},
+        .eventData = nullptr,
+        .reactions = nullptr,
+        .transitions = nullptr
     };
     if (!fsm) return nullptr;
 


### PR DESCRIPTION
* Compiler will throw warnings if all fields are not initialized.
* Change includes to types, since the functions are not used in the headers. This fixes static analysis warnings.