### PR TITLE
fix(fsm_graph): import URL_SECORO_MM from rdf_utils.namespace

### DIFF
--- a/src/coord_dsl/generators/fsm_graph.py
+++ b/src/coord_dsl/generators/fsm_graph.py
@@ -2,7 +2,7 @@ from jinja2 import Environment, FileSystemLoader
 from os.path import basename
 from pathlib import Path
 from rdflib import Graph, Namespace, Literal, RDF, URIRef
-from rdf_utils.uri import URL_SECORO_MM
+from rdf_utils.namespace import URL_SECORO_MM
 from rdf_utils.naming import get_valid_var_name
 from coord_dsl.generators.classes import FSM
 


### PR DESCRIPTION
## What

`fsm_graph.py` imported `URL_SECORO_MM` from `rdf_utils.uri`, but that constant lives in `rdf_utils.namespace` (`URL_SECORO_MM = f"{URL_SECORO}/metamodels"`). The stale import was the only consumer still pointing at `uri`.

## Why it matters

The bad import raised `ImportError` when the `coord_dsl_fsm` textX language loaded. Because textX's `language_descriptions()` eagerly loads **every** registered language, this one failure poisoned the whole textX registry — breaking metamodel builds for all dependents (motion-spec-dsl references `[fsm.Event]`, so it couldn't build either).

## Verification

- `from coord_dsl.generators.fsm_graph import URL_SECORO_MM` → resolves to `https://secorolab.github.io/metamodels`
- `get_fsm_graph()` on `examples/models/fsm/example.fsm` builds the RDF graph (109 triples)
- `textx.metamodel_for_language('coord_dsl_fsm')` and `'scenex'` both load via the registry again